### PR TITLE
README.md: add ulimit flag, disable docker buildkit

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ This repository builds jellifin-tizen with three commands. The resulting file is
 
 ## Build process:
 
-    DOCKER_BUILDKIT=0 docker build --ulimit nofile=65536:65536 -t jellyfin-tizen-build .
+    docker build --ulimit nofile=65536:65536 --progress=plain --no-cache -t jellyfin-tizen-build .
 
     mkdir -p output
     touch output/.test || sudo chown $USER:$USER output
@@ -39,7 +39,7 @@ On the TV:
 - Find the IP address of the TV by going to `Settings > General > Network > Network Status`
 
 ## Run the docker container to use sdb
-    docker run -v "$(pwd)"/output:/output -it jellyfin-tizen-build /bin/bash
+    docker run --ulimit nofile=65536:65536 -v "$(pwd)"/output:/output -it jellyfin-tizen-build /bin/bash
 
 ### Once inside the docker container issue:
 

--- a/README.md
+++ b/README.md
@@ -8,12 +8,12 @@ This repository builds jellifin-tizen with three commands. The resulting file is
 
 ## Build process:
 
-    docker build -t jellyfin-tizen-build .
+    DOCKER_BUILDKIT=0 docker build --ulimit nofile=65536:65536 -t jellyfin-tizen-build .
 
     mkdir -p output
     touch output/.test || sudo chown $USER:$USER output
 
-    docker run -v "$(pwd)/output":/output -it jellyfin-tizen-build
+    docker run --ulimit nofile=65536:65536 -v "$(pwd)/output":/output -it jellyfin-tizen-build
 
     ls -lah output/
     total 18488


### PR DESCRIPTION
Thanks for this project! It worked flawlessly after this small fix.

The tizen installer throws an error if it can not allocate enough file descriptors: `library initialization failed - unable to allocate file descriptor table - out of memory./installer.sh`. The ulimit flag can be used to increase the maximum amount of file descriptors usable by the container.

`DOCKER_BUILDKIT=0` is required for the ulimit flag.